### PR TITLE
Linkedin supports scoping authorization a la OAuth 2.0

### DIFF
--- a/lib/passport-linkedin/strategy.js
+++ b/lib/passport-linkedin/strategy.js
@@ -2,6 +2,7 @@
  * Module dependencies.
  */
 var util = require('util')
+  , url = require('url')
   , OAuthStrategy = require('passport-oauth').OAuthStrategy
   , InternalOAuthError = require('passport-oauth').InternalOAuthError;
 
@@ -46,6 +47,17 @@ function Strategy(options, verify) {
   options.accessTokenURL = options.accessTokenURL || 'https://api.linkedin.com/uas/oauth/accessToken';
   options.userAuthorizationURL = options.userAuthorizationURL || 'https://www.linkedin.com/uas/oauth/authenticate';
   options.sessionKey = options.sessionKey || 'oauth:linkedin';
+
+  // Linkedin supports scoping authorization a la OAuth 2.0
+  var scope = options.scope;
+  if (scope) {
+      var requestTokenURL = url.parse(options.requestTokenURL);
+
+      requestTokenURL.query = requestTokenURL.query || {};
+      requestTokenURL.query.scope = Array.isArray(scope) ? scope.join(',') : scope;
+
+      options.requestTokenURL = url.format(requestTokenURL);
+  }
 
   OAuthStrategy.call(this, options, verify);
   this.name = 'linkedin';


### PR DESCRIPTION
Sadly, it's a vendor-specific extension to OAuth1.0a, so I couldn't just use the OAuth2 strategy.

Allowed permissions can be found at https://developer.linkedin.com/documents/authentication#granting .
