### PR TITLE
Migrate to explicit OAuth1 Strategy, 1.x.x codebase

### DIFF
--- a/lib/passport-linkedin/strategy.js
+++ b/lib/passport-linkedin/strategy.js
@@ -4,8 +4,8 @@
 var util = require('util')
   , url = require('url')
   , querystring = require('querystring')
-  , OAuthStrategy = require('passport-oauth').OAuthStrategy
-  , InternalOAuthError = require('passport-oauth').InternalOAuthError;
+  , OAuthStrategy = require('passport-oauth1').Strategy
+  , InternalOAuthError = require('passport-oauth1').InternalOAuthError;
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-linkedin",
-  "version": "0.1.3",
+  "version": "1.0.0",
   "description": "LinkedIn authentication strategy for Passport.",
   "keywords": ["passport", "linkedin", "auth", "authn", "authentication", "identity"],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "./lib/passport-linkedin",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport-oauth": "0.1.x"
+    "passport-oauth1": "~1.0.1"
   },
   "devDependencies": {
     "vows": "0.6.x"


### PR DESCRIPTION
Use the 1.x.x codebase for passport-oauth, which means
explicitly using the passport-oauth1.Strategy.
Upgrade package.json to match.