### PR TITLE
Adds note about getting https picture URLs (updates README.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,22 @@ email address, and headline, configure strategy like this.
       // verify callback
     ));
 
+
+> **Note on profile images:**
+>
+> To get `https://` avatar images for LinkedIn, you'll need to add the field `picture-url;secure=true`.  For example:
+>
+> ```js
+> passport.use(new LinkedInStrategy({
+>   // clientID, clientSecret and callbackURL
+>   profileFields: ['id', 'first-name', 'last-name', 'email-address', 'headline', 'picture-url; secure=true']
+> },
+> // verify callback
+> ));
+> ```
+>
+
+
 ## Examples
 
 For a complete, working example, refer to the [login example](https://github.com/jaredhanson/passport-linkedin/tree/master/examples/login).

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ email address, and headline, configure strategy like this.
 > // verify callback
 > ));
 > ```
+> 
+> The URL of the avatar image wil be available as `pictureUrl` in the callback from passport.
 >
 
 


### PR DESCRIPTION
Great module, thanks!  Just thought I'd pass along this comment in case it helps anyone else.  And, selfishly, so I remember how to do this next time I use this passport strategy :)


_From Kamyar Mohager at LinkedIn, on the forums:_
Source: https://developer.linkedin.com/forum/ssl-profile-picture-url-https

> Hi everyone,
> 
> We just pushed a fix for this today. Now you can indicate whether you want to fetch the secure or non-secure URL of the profile picture. By setting "secure=true" you're indicating that you want the secure version of the profile URL.
>
> Secure URL fetch:
>
> GET http://api.linkedin.com/v1/people/~:(picture-url;secure=true)
>
> Non-secure URL fetch:
>
> GET http://api.linkedin.com/v1/people/~:(picture-url)
>
> Getting the non secure URL is the same call as before. We've also updated the documentation to reflect this change.
>
>Thanks again!
>Kamyar