### PR TITLE
Update passport-oauth version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "./lib/passport-linkedin",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport-oauth": "0.1.x"
+    "passport-oauth": "1.x"
   },
   "devDependencies": {
     "vows": "0.6.x"


### PR DESCRIPTION
Update passport-oauth dependency, as right now 0.1.x version completely breaks the code, that relies on serializeUser being called with three arguments